### PR TITLE
prevent genkernel from installing firmware files...please read the comment before merging @BlackNoxis 

### DIFF
--- a/app-misc/calamares-config-kogaion/calamares-config-kogaion-2.0.ebuild
+++ b/app-misc/calamares-config-kogaion/calamares-config-kogaion-2.0.ebuild
@@ -13,8 +13,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""
 
-DEPEND="app-admin/calamares"
-RDEPEND="${DEPEND}"
+RDEPEND="app-admin/calamares"
 
 S="${FILESDIR}"
 

--- a/sys-kernel/genkernel-next/genkernel-next-63.ebuild
+++ b/sys-kernel/genkernel-next/genkernel-next-63.ebuild
@@ -54,7 +54,7 @@ src_prepare() {
 	# kernel building process ... this patch prevents this behaviour, and relies
 	# on linux-firmware already being installed ... and since linux-firmware 
 	# is a dep of our kernel anyway ... you get the point
-	# epatch "${FILESDIR}/${PN}-dont-install-firmware-due-to-linux-firmware.patch"
+	epatch "${FILESDIR}/${PN}-dont-install-firmware-due-to-linux-firmware.patch"
 }
 
 src_install() {


### PR DESCRIPTION
our new buildsystem revealed that genkernel installs firmware files, even
if we use external linux-firmware package, thus creating conflicts during
kernel building process ... this patch prevents this behaviour, and relies
on linux-firmware already being installed ... and since linux-firmware 
is a dep of our kernel anyway ... you get the point

another way of fixing this was to patch the kernel config
but it would have worked only on following kernels
I'd rather fix this in userspace